### PR TITLE
Switch to git read-only urls

### DIFF
--- a/bin/mad
+++ b/bin/mad
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 VERSION="0.3.0"
-REMOTE=git@github.com:visionmedia/mad-pages.git
-REMOTE_MAD=git@github.com:visionmedia/mad.git
+REMOTE=git://github.com/visionmedia/mad-pages.git
+REMOTE_MAD=git://github.com/visionmedia/mad.git
 CONFIG=$(dirname $0)/../etc/mad.conf
 MAD_CONFIG=${MAD_CONFIG:-$CONFIG}
 


### PR DESCRIPTION
I had trouble with -u and -U in environments without a github ssh key. Switching the mad and mad-pages repo urls to git:// seems a reasonable fix I think, can't see any other uses of those values that it might break.

Cheers.
