### PR TITLE
Use '-a' (short and more compatible form of '--multiple') option for basename

### DIFF
--- a/bin/mad
+++ b/bin/mad
@@ -21,7 +21,7 @@ list_pages() {
     test ! -z $path \
       && test -d $path \
       && find $path -type f -print0 \
-      | xargs -0 basename \
+      | xargs -0 basename -a \
       | grep -iv 'readme*' \
       | grep '.md$' \
       | perl -pe 's|^(.*)\.md$|    \1|;'


### PR DESCRIPTION
Closes isse #9, even on mac os x, I hope.
