### PR TITLE
Mad patch 1

### DIFF
--- a/bin/mad
+++ b/bin/mad
@@ -22,7 +22,7 @@ list_pages() {
   echo
   printf "  \033[1mmad pages:\033[0m\n"
   echo
-  for path in ${path_array[@]}; do
+  for path in "${path_array[@]}"; do
     [[ -z "$path" || ! -d "$path" ]] && continue
     while read -r -d '' file; do
       file=${file##*/} # basename
@@ -47,7 +47,7 @@ display() {
   local path_array=
   IFS=: read -a path_array <<< "$paths"
 
-  for path in ${path_array[@]}; do
+  for path in "${path_array[@]}"; do
     local file=$path/$page
     local ext=$path/$page.md
     [[ -f "$file" ]] && display_file "$file"


### PR DESCRIPTION
- Quote all potentially dangerous expansions
  - http://mywiki.wooledge.org/BashFAQ/028
- Sanity check all calls to `chdir(2)`
- Prefer PAGER env variable and fallback on `less(1)`
  - Passing exit code from PAGER properly, removing unnecessary call to exit
- Prefer bash redirects over `cat(1)`
- Use bash arrays to load and iterate over paths safely
- Replace external programs with bash built-ins
  - Parameter expansion is more efficient than `dirname(1)`, etc.
  - `test(1)`, `[(1)` are limited, external commands. `[[` is built-in and more robust
  - http://mywiki.wooledge.org/BashFAQ/031
- Use bash builtin regex and paramater expansion to filter files
- Drop the dependency to perl in `list_pages()`
