### PR TITLE
minor fixes

### DIFF
--- a/bin/mad
+++ b/bin/mad
@@ -82,6 +82,8 @@ display_from_stdin() {
 display_file() {
   local heading=$(get heading)
   local code=$(get code)
+  local link=$(get link)
+  local url=$(get url)
   local strong=$(get strong)
   local em=$(get em)
 
@@ -93,6 +95,7 @@ display_file() {
       s|\*(.+?)\*|\e[$em\1\e[0m|g; \
       s|_(.+?)_|\e[$em\1\e[0m|g; \
       s|    (.+)|    \e[$code\1\e[0m|g; \
+      s|\[(.+)\]\((.+)\)|\e[$em\e[$link\1\e[0m \e[$url(\2)\e[0m|g; \
       s|<(.+?)>||g; \
       s|^|  |;" \
     | less -R

--- a/bin/mad
+++ b/bin/mad
@@ -64,7 +64,7 @@ display() {
 #
 
 get() {
-  grep "$1" "$MAD_CONFIG" | awk '{ print $2 }'
+  grep "^$1:" "$MAD_CONFIG" | awk '{ print $2 }'
 }
 
 #

--- a/bin/mad
+++ b/bin/mad
@@ -3,7 +3,13 @@
 VERSION="0.4.1"
 REMOTE=git://github.com/visionmedia/mad-pages.git
 REMOTE_MAD=git://github.com/visionmedia/mad.git
-CONFIG=$(dirname $0)/../etc/mad.conf
+
+BINPATH=$0
+if [ -h "$BINPATH" ]; then
+    BINPATH=$(readlink "$BINPATH")
+fi
+MAD_ROOT=$(dirname "$BINPATH")
+CONFIG=${MAD_ROOT}/../etc/mad.conf
 MAD_CONFIG=${MAD_CONFIG:-$CONFIG}
 
 #
@@ -36,7 +42,7 @@ list_pages() {
 display() {
   IFS=":"
   local page=$1
-  local paths=".:$MAD_PATH:$(dirname $0)/../share/mad:/usr/share/mad"
+  local paths=".:$MAD_PATH:${MAD_ROOT}/../share/mad:/usr/share/mad"
 
   for path in $paths; do
     local file=$path/$page
@@ -98,7 +104,7 @@ display_file() {
 #
 
 display_mad_usage() {
-  display_file $(dirname $0)/../share/mad/mad.md
+  display_file ${MAD_ROOT}/../share/mad/mad.md
   exit
 }
 
@@ -107,7 +113,7 @@ display_mad_usage() {
 #
 
 install_all_remote() {
-  local path=$(dirname $0)/../share/mad
+  local path=${MAD_ROOT}/../share/mad
   echo
   echo "  ... cloning repo"
   cd /tmp && rm -fr mad-pages

--- a/etc/mad.conf
+++ b/etc/mad.conf
@@ -2,3 +2,5 @@ heading: 1m
 code: 90m
 strong: 1m
 em: 4m
+link: 4;34;48m
+url: 90m


### PR DESCRIPTION
Hi,

The first patch is allows the script to resolve it's proper install path, in case it has been symlinked to somewhere else.

The second one is minor tinkering with the config file parsing to allow grep to match the only the exact keyword, at the start of the line thus preventing false positives from comment lines, in case of a future new keyword contain the current one.
